### PR TITLE
Fix Terraform Driver and add cluster ResDef matching

### DIFF
--- a/terraform/matching.tf
+++ b/terraform/matching.tf
@@ -17,3 +17,18 @@ resource "humanitec_resource_definition_criteria" "criteria4" {
   resource_definition_id = humanitec_resource_definition.postgres.id
   app_id                 = "app3"
 }
+
+
+# Matching criteria for the target Kubernetes cluster
+resource "humanitec_resource_definition_criteria" "cluster-app1" {
+  resource_definition_id = var.k8s_resDef
+  app_id                 = "app1"
+}
+resource "humanitec_resource_definition_criteria" "cluster-app2" {
+  resource_definition_id = var.k8s_resDef
+  app_id                 = "app2"
+}
+resource "humanitec_resource_definition_criteria" "cluster-app3" {
+  resource_definition_id = var.k8s_resDef
+  app_id                 = "app3"
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -18,3 +18,6 @@ variable "org" {
 
 variable "token" {
 }
+
+variable "k8s_resDef" {
+}

--- a/terraform/resdef.tf
+++ b/terraform/resdef.tf
@@ -5,7 +5,7 @@ variable "instance_type" {
 resource "humanitec_resource_definition" "redis" {
   name        = "redis"
   id          = "redis"
-  driver_type = "${var.org}/terraform"
+  driver_type = "humanitec/terraform"
   type        = "redis"
 
   driver_inputs = {
@@ -37,7 +37,7 @@ resource "humanitec_resource_definition" "redis" {
 resource "humanitec_resource_definition" "bucket" {
   name        = "bucket"
   id          = "bucket"
-  driver_type = "${var.org}/terraform"
+  driver_type = "humanitec/terraform"
   type        = "s3"
 
   driver_inputs = {
@@ -69,7 +69,7 @@ resource "humanitec_resource_definition" "bucket" {
 resource "humanitec_resource_definition" "postgres" {
   name        = "postgres"
   id          = "postgres"
-  driver_type = "${var.org}/terraform"
+  driver_type = "humanitec/terraform"
   type        = "postgres"
 
   driver_inputs = {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -2,3 +2,5 @@
 org = ""
 # The Humanitec API Token.
 token = ""
+# The id of the Resource Definition of the target Kubernetes Cluster
+k8s_resDef  = ""


### PR DESCRIPTION
This PR fixes a deployment error caused by the Terraform Driver "`<org-id>/terraform`" being used instead of "`humanitec/terraform`".

Now that the Default `k8s-cluster` Resource Definition is not available in new orgs, also adds a K8s cluster as a prerequisite, and adds matching criteria to that cluster to properly direct the deployments.

There is a [related PR](https://github.com/humanitec/developers-docs/pull/477) in the developer-docs repo. The two PRs can be merged independently though.